### PR TITLE
Qt6 proposed changes

### DIFF
--- a/qwebdavlib/qwebdav.cpp
+++ b/qwebdavlib/qwebdav.cpp
@@ -499,9 +499,9 @@ QNetworkReply* QWebdav::propfind(const QString& path, const QWebdav::PropNames& 
     {
         foreach (const QString key, props[ns])
             if (ns == "DAV:")
-                query += "<D:" + key + "/>";
+                query += "<D:" + key.toLatin1() + "/>";
             else
-                query += "<" + key + " xmlns=\"" + ns + "\"/>";
+                query += "<" + key.toLatin1() + " xmlns=\"" + ns.toLatin1() + "\"/>";
     }
     query += "</D:prop>";
     query += "</D:propfind>";
@@ -535,13 +535,13 @@ QNetworkReply* QWebdav::proppatch(const QString& path, const QWebdav::PropValues
 
         for (i = props[ns].constBegin(); i != props[ns].constEnd(); ++i) {
             if (ns == "DAV:") {
-                query += "<D:" + i.key() + ">";
-                query += i.value().toString();
-                query += "</D:" + i.key() + ">" ;
+                query += "<D:" + i.key().toLatin1() + ">";
+                query += i.value().toString().toLatin1();
+                query += "</D:" + i.key().toLatin1() + ">" ;
             } else {
-                query += "<" + i.key() + " xmlns=\"" + ns + "\">";
-                query += i.value().toString();
-                query += "</" + i.key() + " xmlns=\"" + ns + "\"/>";
+                query += "<" + i.key().toLatin1() + " xmlns=\"" + ns.toLatin1() + "\">";
+                query += i.value().toString().toLatin1();
+                query += "</" + i.key().toLatin1() + " xmlns=\"" + ns.toLatin1() + "\"/>";
             }
         }
     }

--- a/qwebdavlib/qwebdavdirparser.cpp
+++ b/qwebdavlib/qwebdavdirparser.cpp
@@ -49,6 +49,7 @@
 ****************************************************************************/
 
 #include "qwebdavdirparser.h"
+#include <algorithm>
 
 QWebdavDirParser::QWebdavDirParser(QObject *parent) : QObject(parent)
   ,m_webdav(0)
@@ -58,7 +59,7 @@ QWebdavDirParser::QWebdavDirParser(QObject *parent) : QObject(parent)
   ,m_busy(false)
   ,m_abort(false)
 {
-    m_mutex.reset(new QMutex(QMutex::Recursive));
+    m_mutex.reset(new QRecursiveMutex());
 }
 
 QWebdavDirParser::~QWebdavDirParser()
@@ -328,7 +329,7 @@ void QWebdavDirParser::parseMultiResponse(const QByteArray &data)
 
     }
 
-    qSort(m_dirList.begin(), m_dirList.end());
+    std::sort(m_dirList.begin(), m_dirList.end());
 }
 
 void QWebdavDirParser::parseResponse(const QDomElement &dom)
@@ -374,7 +375,7 @@ void QWebdavDirParser::davParsePropstats(const QString &path, const QDomNodeList
 #endif
 
     // name
-    QStringList pathElements = path_.split('/', QString::SkipEmptyParts);
+    QStringList pathElements = path_.split('/', Qt::SkipEmptyParts);
     name = pathElements.isEmpty() ? "/" : pathElements.back();
 
     for ( int i = 0; i < propstats.count(); i++) {

--- a/qwebdavlib/qwebdavdirparser.h
+++ b/qwebdavlib/qwebdavdirparser.h
@@ -105,7 +105,7 @@ protected:
     QDateTime parseDateTime( const QString &input, const QString &type);
 
 private:
-    QScopedPointer<QMutex> m_mutex;
+    QScopedPointer<QRecursiveMutex> m_mutex;
     QWebdav *m_webdav;
     QNetworkReply *m_reply;
     QList<QWebdavItem> m_dirList;

--- a/qwebdavlib/qwebdavlib.pro
+++ b/qwebdavlib/qwebdavlib.pro
@@ -6,8 +6,8 @@ QT       -= gui
 TARGET = qwebdav
 TEMPLATE = lib
 
-# Enable DEBUG output with qDebug()
-DEFINES += DEBUG_WEBDAV
+# SG: remove debugging define
+#DEFINES += DEBUG_WEBDAV
 
 # Enable extended WebDAV properties (see QWebDavItem.h/cpp)
 #DEFINES += QWEBDAVITEM_EXTENDED_PROPERTIES
@@ -30,3 +30,8 @@ OTHER_FILES += \
     CHANGES \
     LICENSE \
     README
+
+headers.files = $$HEADERS
+headers.path = $$WEBDAV_INCLUDE_DIR
+target.path = $$WEBDAV_LIB_DIR
+INSTALLS += headers target


### PR DESCRIPTION
Changes made to remove API that was removed in Qt6.

Also updated the qmake .pro file so we don't have to hack it in our build script.

WEBDAV_INCLUDE_DIR and WEBDAV_LIB_DIR variables can just be passed in through the command line.